### PR TITLE
(GH-6) Upgrade to Cake 0.23.0

### DIFF
--- a/cake.config
+++ b/cake.config
@@ -1,0 +1,3 @@
+[Nuget]
+; Use the new InProcess client, because some packages have long file paths.
+UseInProcessClient=true 

--- a/setup.cake
+++ b/setup.cake
@@ -9,7 +9,8 @@ BuildParameters.SetParameters(
     title: "Cake.Issues.Reporting.Generic",
     repositoryOwner: "cake-contrib",
     repositoryName: "Cake.Issues.Reporting.Generic",
-    appVeyorAccountName: "cakecontrib");
+    appVeyorAccountName: "cakecontrib",
+    shouldRunCodecov: false);
 
 BuildParameters.PrintParameters(Context);
 

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.21.1" />
+    <package id="Cake" version="0.23.0" />
 </packages>


### PR DESCRIPTION
Update to Cake 0.23.0 for compatibility with latest Cake.Recipe

Fixes #6