### PR TITLE
(GH-13) Add support for LINQ in templates

### DIFF
--- a/src/Cake.Issues.Reporting.Generic/RazorEngineReferenceResolver.cs
+++ b/src/Cake.Issues.Reporting.Generic/RazorEngineReferenceResolver.cs
@@ -25,6 +25,7 @@
 
             // All assemblies which can be used inside the templates need to be listed here.
             yield return CompilerReference.From(this.FindLoaded(loadedAssemblies, "System.dll"));
+            yield return CompilerReference.From(this.FindLoaded(loadedAssemblies, "System.Core.dll"));
             yield return CompilerReference.From(this.FindLoaded(loadedAssemblies, "netstandard.dll"));
             yield return CompilerReference.From(this.FindLoaded(loadedAssemblies, "Cake.Core.dll"));
             yield return CompilerReference.From(this.FindLoaded(loadedAssemblies, "Cake.Issues.dll"));


### PR DESCRIPTION
Loads `System.Core` which adds support for LINQ in templates back

Fixes #13 