### PR TITLE
(GH-22) Show PriorityName instead of Priority

### DIFF
--- a/src/Cake.Issues.Reporting.Generic/Templates/DataTable.cshtml
+++ b/src/Cake.Issues.Reporting.Generic/Templates/DataTable.cshtml
@@ -75,7 +75,7 @@
                     @foreach (var issue in group.OrderByDescending(x => x.Priority))
                     {
                     <tr>
-                        <td>@issue.Priority</td>
+                        <td>@issue.PriorityName</td>
                         <td>@issue.Project</td>
                         <td>
                             @if (issue.AffectedFileRelativePath != null)


### PR DESCRIPTION
Show `PriorityName` instead of `Priority` in DataTable template.

Fixes #22
