### PR TITLE
(GH-24) Show ProviderName instead of ProviderType

### DIFF
--- a/src/Cake.Issues.Reporting.Generic/Templates/DataTable.cshtml
+++ b/src/Cake.Issues.Reporting.Generic/Templates/DataTable.cshtml
@@ -54,7 +54,7 @@
         {
             if (groupedIssues.Count() > 1)
             {
-                <h2>@group.Key</h2>
+                <h2>@group.First().ProviderName</h2>
             }
 
             var tableId = group.Key.Replace(".", "-").ToLower();


### PR DESCRIPTION
Show `ProviderName` instead of `ProviderType` in DataTable template.

Fixes #23