### PR TITLE
(GH-49) Add IDE integration option

### DIFF
--- a/src/Cake.Issues.Reporting.Generic.Tests/Cake.Issues.Reporting.Generic.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Generic.Tests/Cake.Issues.Reporting.Generic.Tests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="ColumnSortOrderExtensionsTests.cs" />
     <Compile Include="DevExtremeThemeExtensionsTests.cs" />
     <Compile Include="ExceptionAssertExtensions.cs" />
+    <Compile Include="IdeIntegrationSettingsTests.cs" />
     <Compile Include="HtmlDxDataGridColumnDescriptionTests.cs" />
     <Compile Include="IIssueExtensionsTests.cs" />
     <Compile Include="UriExtensionsTests.cs" />

--- a/src/Cake.Issues.Reporting.Generic.Tests/IdeIntegrationSettingsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/IdeIntegrationSettingsTests.cs
@@ -1,0 +1,162 @@
+﻿namespace Cake.Issues.Reporting.Generic.Tests
+{
+    using System;
+    using Cake.Issues.Testing;
+    using Shouldly;
+    using Xunit;
+
+    public sealed class IdeIntegrationSettingsTests
+    {
+        public sealed class TheGetOpenInIdeCallMethod
+        {
+            [Fact]
+            public void Should_Throw_If_FilePathExpression_Is_Null()
+            {
+                // Given
+                var ideIntegrationSettings = new IdeIntegrationSettings();
+                string filePathExpression = null;
+                var lineExpression = "line";
+
+                // When
+                var result = Record.Exception(() =>
+                    ideIntegrationSettings.GetOpenInIdeCall(filePathExpression, lineExpression));
+
+                // Then
+                result.IsArgumentNullException("filePathExpression");
+            }
+
+            [Fact]
+            public void Should_Throw_If_FilePathExpression_Is_Empty()
+            {
+                // Given
+                var ideIntegrationSettings = new IdeIntegrationSettings();
+                var filePathExpression = string.Empty;
+                var lineExpression = "line";
+
+                // When
+                var result = Record.Exception(() =>
+                    ideIntegrationSettings.GetOpenInIdeCall(filePathExpression, lineExpression));
+
+                // Then
+                result.IsArgumentOutOfRangeException("filePathExpression");
+            }
+
+            [Fact]
+            public void Should_Throw_If_FilePathExpression_Is_WhiteSpace()
+            {
+                // Given
+                var ideIntegrationSettings = new IdeIntegrationSettings();
+                var filePathExpression = " ";
+                var lineExpression = "line";
+
+                // When
+                var result = Record.Exception(() =>
+                    ideIntegrationSettings.GetOpenInIdeCall(filePathExpression, lineExpression));
+
+                // Then
+                result.IsArgumentOutOfRangeException("filePathExpression");
+            }
+
+            [Fact]
+            public void Should_Throw_If_LineExpression_Is_Null()
+            {
+                // Given
+                var ideIntegrationSettings = new IdeIntegrationSettings();
+                var filePathExpression = "file";
+                string lineExpression = null;
+
+                // When
+                var result = Record.Exception(() =>
+                    ideIntegrationSettings.GetOpenInIdeCall(filePathExpression, lineExpression));
+
+                // Then
+                result.IsArgumentNullException("lineExpression");
+            }
+
+            [Fact]
+            public void Should_Throw_If_LineExpression_Is_Empty()
+            {
+                // Given
+                var ideIntegrationSettings = new IdeIntegrationSettings();
+                var filePathExpression = "file";
+                var lineExpression = string.Empty;
+
+                // When
+                var result = Record.Exception(() =>
+                    ideIntegrationSettings.GetOpenInIdeCall(filePathExpression, lineExpression));
+
+                // Then
+                result.IsArgumentOutOfRangeException("lineExpression");
+            }
+
+            [Fact]
+            public void Should_Throw_If_LineExpression_Is_WhiteSpace()
+            {
+                // Given
+                var ideIntegrationSettings = new IdeIntegrationSettings();
+                var filePathExpression = "file";
+                var lineExpression = " ";
+
+                // When
+                var result = Record.Exception(() =>
+                    ideIntegrationSettings.GetOpenInIdeCall(filePathExpression, lineExpression));
+
+                // Then
+                result.IsArgumentOutOfRangeException("lineExpression");
+            }
+
+            [Fact]
+            public void Should_Return_Null_If_OpenInIdeCall_Is_Not_Set()
+            {
+                // Given
+                var ideIntegrationSettings = new IdeIntegrationSettings();
+                var filePathExpression = "file";
+                var lineExpression = "line";
+
+                // When
+                var result = ideIntegrationSettings.GetOpenInIdeCall(filePathExpression, lineExpression);
+
+                // Then
+                result.ShouldBeNull();
+            }
+
+            [Fact]
+            public void Should_Replace_FilePath_Token()
+            {
+                // Given
+                var ideIntegrationSettings =
+                    new IdeIntegrationSettings
+                    {
+                        OpenInIdeCall = "Foo{FilePath}Bar"
+                    };
+                var filePathExpression = "file";
+                var lineExpression = "line";
+
+                // When
+                var result = ideIntegrationSettings.GetOpenInIdeCall(filePathExpression, lineExpression);
+
+                // Then
+                result.ShouldBe("FoofileBar");
+            }
+
+            [Fact]
+            public void Should_Replace_Line_Token()
+            {
+                // Given
+                var ideIntegrationSettings =
+                    new IdeIntegrationSettings
+                    {
+                        OpenInIdeCall = "Foo{Line}Bar"
+                    };
+                var filePathExpression = "file";
+                var lineExpression = "line";
+
+                // When
+                var result = ideIntegrationSettings.GetOpenInIdeCall(filePathExpression, lineExpression);
+
+                // Then
+                result.ShouldBe("FoolineBar");
+            }
+        }
+    }
+}

--- a/src/Cake.Issues.Reporting.Generic/Cake.Issues.Reporting.Generic.csproj
+++ b/src/Cake.Issues.Reporting.Generic/Cake.Issues.Reporting.Generic.csproj
@@ -78,6 +78,7 @@
     <Compile Include="GenericIssueReportFormatSettingsExtensions.cs" />
     <Compile Include="GenericIssueReportGenerator.cs" />
     <Compile Include="GenericIssueReportFormatSettings.cs" />
+    <Compile Include="IdeIntegrationSettings.cs" />
     <Compile Include="IIssueExtensions.cs" />
     <Compile Include="ReportColumn.cs" />
     <Compile Include="UriExtensions.cs" />

--- a/src/Cake.Issues.Reporting.Generic/HtmlDxDataGridOption.cs
+++ b/src/Cake.Issues.Reporting.Generic/HtmlDxDataGridOption.cs
@@ -300,6 +300,13 @@
         /// If setting this the matching <see cref="JQueryVersion"/> needs to also be set.
         /// Default value is <c>18.2.7</c>.
         /// </summary>
-        DevExtremeVersion
+        DevExtremeVersion,
+
+        /// <summary>
+        /// Settings for having functionality to open files affected by issues in IDEs.
+        /// Value needs to be an instance of <see cref="IdeIntegrationSettings"/>.
+        /// Default value is <c>null</c>.
+        /// </summary>
+        IdeIntegrationSettings
     }
 }

--- a/src/Cake.Issues.Reporting.Generic/IdeIntegrationSettings.cs
+++ b/src/Cake.Issues.Reporting.Generic/IdeIntegrationSettings.cs
@@ -1,0 +1,50 @@
+﻿namespace Cake.Issues.Reporting.Generic
+{
+    /// <summary>
+    /// Settings how issues should be integrated to IDEs.
+    /// </summary>
+    public class IdeIntegrationSettings
+    {
+        /// <summary>
+        /// Gets or sets additional JavaScript which should be added.
+        /// </summary>
+        public string JavaScript { get; set; }
+
+        /// <summary>
+        /// Gets or sets JavaScript which should be called to open the file affected by an issue in an IDE.
+        /// </summary>
+        public string OpenInIdeCall { get; set; }
+
+        /// <summary>
+        /// Gets or sets text which should be shown in the drop down menu for opening the file affected
+        /// by an issue in an IDE.
+        /// Default value is <c>Open in IDE</c>.
+        /// </summary>
+        public string MenuEntryText { get; set; } = "Open in IDE";
+
+        /// <summary>
+        /// Returns the JavaScript which should be called to open the file affected by an issue in an IDE
+        /// with all patterns of <see cref="OpenInIdeCall"/> replaced.
+        /// </summary>
+        /// <param name="filePathExpression">Expression which should be used to get the path and name
+        /// of the file at runtime.</param>
+        /// <param name="lineExpression">Expression which should be used to get the line number at runtime.</param>
+        /// <returns>JavaScript which should be called to open the file affected by an issue in an IDE
+        /// with all patterns replaced.</returns>
+        public string GetOpenInIdeCall(string filePathExpression, string lineExpression)
+        {
+            filePathExpression.NotNullOrWhiteSpace(nameof(filePathExpression));
+            lineExpression.NotNullOrWhiteSpace(nameof(lineExpression));
+
+            if (string.IsNullOrWhiteSpace(this.OpenInIdeCall))
+            {
+                return null;
+            }
+
+            return
+                this.OpenInIdeCall
+                    .Replace("{FilePath}", filePathExpression)
+                    .Replace("{Line}", lineExpression);
+        }
+    }
+}

--- a/src/Cake.Issues.Reporting.Generic/Templates/DxDataGrid.cshtml
+++ b/src/Cake.Issues.Reporting.Generic/Templates/DxDataGrid.cshtml
@@ -42,6 +42,7 @@
     var groupedColumns = ViewBagHelper.ValueOrDefault(ViewBag.GroupedColumns, new List<ReportColumn> { ReportColumn.ProviderName });
     var sortedColumns = ViewBagHelper.ValueOrDefault(ViewBag.SortedColumns, new List<ReportColumn> { ReportColumn.PriorityName, ReportColumn.ProjectName, ReportColumn.FileDirectory, ReportColumn.FileName, ReportColumn.Line });
     FileLinkSettings fileLinkSettings = ViewBagHelper.ValueOrDefault(ViewBag.FileLinkSettings, new FileLinkSettings());
+    IdeIntegrationSettings ideIntegrationSettings = ViewBagHelper.ValueOrDefault<IdeIntegrationSettings>(ViewBag.IdeIntegrationSettings, null);
     List<HtmlDxDataGridColumnDescription> additionalColumns = ViewBagHelper.ValueOrDefault(ViewBag.AdditionalColumns, new List<HtmlDxDataGridColumnDescription>());
     string jQueryLocation = ViewBagHelper.ValueOrDefault(ViewBag.JQueryLocation, "https://ajax.aspnetcdn.com/ajax/jquery/");
     string jQueryVersion = ViewBagHelper.ValueOrDefault(ViewBag.JQueryVersion, "3.1.0");
@@ -61,10 +62,10 @@
                 addPriorityName: priorityNameVisible,
                 addProjectPath: projectPathVisible,
                 addProjectName: projectNameVisible,
-                addFilePath: filePathVisible,
+                addFilePath: filePathVisible || ideIntegrationSettings != null,
                 addFileDirectory: fileDirectoryVisible,
                 addFileName: fileNameVisible,
-                addLine: lineVisible,
+                addLine: lineVisible || ideIntegrationSettings != null,
                 addRule: ruleVisible,
                 addRuleUrl: ruleVisible || ruleUrlVisible,
                 addMessage: messageVisible,
@@ -94,6 +95,30 @@
     <link rel="stylesheet" type="text/css" href="@(devExtremeLocation)@(devExtremeVersion)/css/@(theme.GetCssFileName())" />
     @* DevExtreme library *@
     <script type="text/javascript" src="@(devExtremeLocation)@(devExtremeVersion)/js/dx.all.js"></script>
+    @* Additional JavaScript for IDE integration *@
+    @if (ideIntegrationSettings != null && !string.IsNullOrWhiteSpace(ideIntegrationSettings.JavaScript))
+    {
+        <script type="text/javascript">
+            @Raw(ideIntegrationSettings.JavaScript)
+        </script>
+    }
+
+    <style>
+        @* Styles for making sure drop down glyph is not shown for menu in file column in any theme *@
+        td[role=gridcell] .dx-menu-item-popout
+        {
+            display: none;
+        }
+        td[role=gridcell] .dx-icon
+        {
+            margin: 0px !important;
+        }
+        @* Style for making sure menu in file column in any theme is not too high *@
+        .dx-datagrid .dx-menu .dx-menu-item .dx-menu-item-content, .dx-datagrid-container .dx-menu .dx-menu-item .dx-menu-item-content
+        {
+            padding: 0px;
+        }
+    </style>
 </head>
 <body class="dx-viewport">
     @if (showHeader)
@@ -110,7 +135,37 @@
     </script>
 
     <script type="text/javascript">
-        $(function(){
+        $(function () {
+            @if (ideIntegrationSettings != null && !string.IsNullOrWhiteSpace(ideIntegrationSettings.OpenInIdeCall))
+            {
+                <text>
+                    @* Creates the menu in the file column *@
+                    function getFileCellMenuElement(filePath, line) {
+                        var element =
+                            $('<div>')
+                                .css("float", "right")
+                                .dxMenu({
+                                    items: [{
+                                        text: "",
+                                        icon: "overflow",
+                                        items: [
+                                            {
+                                                text: "@ideIntegrationSettings.MenuEntryText",
+                                                action: "openInIde"
+                                            }
+                                        ]
+                                    }],
+                                    onItemClick: function (e) {
+                                        if (e.itemData.action === "openInIde") {
+                                            @Raw(ideIntegrationSettings.GetOpenInIdeCall("filePath", "line"))
+                                        }
+                                    }
+                                });
+                        return element;
+                    }
+                </text>
+            };
+
             $("#gridContainer").dxDataGrid({
                 dataSource: issues,
                 loadPanel: {
@@ -295,22 +350,33 @@
                                     @:sortIndex: @sortedColumns.IndexOf(ReportColumn.FileName),
                                     @:sortOrder: "@fileNameSortOrder.ToShortString()",
                                 }
-                                @if (fileLinkSettings != null && !string.IsNullOrWhiteSpace(fileLinkSettings.FileLinkPattern))
-                                {
-                                    <text>
-                                        cellTemplate: function (container, options) {
-                                            if (options.data["FileLink"]) {
-                                                $('<a>', {
-                                                    text: options.value,
-                                                    href: options.data["FileLink"],
-                                                    target: "_blank"
-                                                }).appendTo(container);
-                                            }
-                                            else {
-                                                container.text(options.value);
-                                            }
-                                        }
-                                    </text>
+                                cellTemplate: function (container, options) {
+                                    if (options.data["FileLink"]) {
+                                        var $wrapper =
+                                            $('<div>')
+                                                .css("float", "left");
+                                        var $link =
+                                            $('<a>', {
+                                                text: options.value,
+                                                href: options.data["FileLink"],
+                                                target: "_blank"
+                                            });
+                                        $wrapper.append($link);
+                                        $wrapper.appendTo(container);
+                                    }
+                                    else {
+                                        $('<div>')
+                                            .text(options.value)
+                                            .css("float", "left")
+                                            .appendTo(container);
+                                    }
+                                    @if (ideIntegrationSettings != null && !string.IsNullOrWhiteSpace(ideIntegrationSettings.OpenInIdeCall))
+                                    {
+                                        <text>
+                                            getFileCellMenuElement(options.data["FilePath"], options.data["Line"])
+                                                .appendTo(container);
+                                        </text>
+                                    }
                                 }
                             },
                         </text>


### PR DESCRIPTION
Add IDE integration option. Currently only supported for HtmlDxDataGrid and TeamCityAddin

Fixes #49 

## TODO
- [x] Add IDE integration settings
- [x] Add menu to file column
- [x] Make sure menu looks good in all themes (alignment of text in file column if menu is added, icon, ...)
