### PR TITLE
Remove cache entry for AppVeyor which is no longer required

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,5 +27,4 @@ branches:
 #  Build Cache                    #
 #---------------------------------#
 cache:
-- src\packages -> src\**\packages.config
 - tools -> setup.cake


### PR DESCRIPTION
Remove cache entry for AppVeyor which is no longer required since we now use global package folder