### PR TITLE
 (GH-217) Support HTML for message 

### DIFF
--- a/src/Cake.Issues.Reporting.Generic/Templates/DxDataGrid.cshtml
+++ b/src/Cake.Issues.Reporting.Generic/Templates/DxDataGrid.cshtml
@@ -72,7 +72,7 @@
                 addLine: lineVisible || ideIntegrationSettings != null,
                 addRule: ruleVisible,
                 addRuleUrl: ruleVisible || ruleUrlVisible,
-                addMessageText: messageVisible,
+                addMessageHtml: messageVisible,
                 fileLinkSettings: fileLinkSettings,
                 additionalValues: additionalColumns.ToDictionary(x => x.Id, x => x.ValueRetriever));
 
@@ -494,7 +494,8 @@
                         <text>
                             {
                                 caption: "Message",
-                                dataField: "MessageText",
+                                dataField: "MessageHtml",
+                                encodeHtml: false,
                                 visibleIndex: @((int)ReportColumn.Message),
                                 @if (groupedColumns.Contains(ReportColumn.Message))
                                 {


### PR DESCRIPTION
Use HTML message if available for HtmlDxDataGrid template.

Fixes #217 