### PR TITLE
Fix Example for Cake.Issues.Reporting

### DIFF
--- a/docs/examples/custom-template.md
+++ b/docs/examples/custom-template.md
@@ -21,8 +21,8 @@ See [pinning addin versions](https://cakebuild.net/docs/tutorials/pinning-cake-v
 #tool "nuget:?package=MSBuild.Extension.Pack"
 #addin "Cake.Issues"
 #addin "Cake.Issues.MsBuild"
-#addin "Cake.Reporting"
-#addin "Cake.Reporting.Generic"
+#addin "Cake.Issues.Reporting"
+#addin "Cake.Issues.Reporting.Generic"
 
 Task("Create-IssueReport").Does(() =>
 {

--- a/docs/examples/default-template.md
+++ b/docs/examples/default-template.md
@@ -16,8 +16,8 @@ See [pinning addin versions](https://cakebuild.net/docs/tutorials/pinning-cake-v
 #tool "nuget:?package=MSBuild.Extension.Pack"
 #addin "Cake.Issues"
 #addin "Cake.Issues.MsBuild"
-#addin "Cake.Reporting"
-#addin "Cake.Reporting.Generic"
+#addin "Cake.Issues.Reporting"
+#addin "Cake.Issues.Reporting.Generic"
 
 Task("Create-IssueReport").Does(() =>
 {


### PR DESCRIPTION
I think in example typo.
nuget package:"Cake.Issues.Reporting" and "Cake.Issues.Reporting.Generic"
