### PR TITLE
Update to SDK style projecst

### DIFF
--- a/nuspec/nuget/Cake.Issues.Reporting.Generic.nuspec
+++ b/nuspec/nuget/Cake.Issues.Reporting.Generic.nuspec
@@ -26,10 +26,10 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="Cake.Issues.Reporting.Generic.dll" target="lib\net46" />
-    <file src="Cake.Issues.Reporting.Generic.pdb" target="lib\net46" />
-    <file src="Cake.Issues.Reporting.Generic.xml" target="lib\net46" />
-    <file src="RazorEngine.dll" target="lib\net46" />
-    <file src="System.Web.Razor.dll" target="lib\net46" />
+    <file src="net461\Cake.Issues.Reporting.Generic.dll" target="lib\net461" />
+    <file src="net461\Cake.Issues.Reporting.Generic.pdb" target="lib\net461" />
+    <file src="net461\Cake.Issues.Reporting.Generic.xml" target="lib\net461" />
+    <file src="net461\RazorEngine.dll" target="lib\net461" />
+    <file src="net461\System.Web.Razor.dll" target="lib\net461" />
   </files>
 </package>

--- a/src/Cake.Issues.Reporting.Generic.Tests/Cake.Issues.Reporting.Generic.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Generic.Tests/Cake.Issues.Reporting.Generic.Tests.csproj
@@ -1,44 +1,25 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{1E92A970-E905-4DF8-8ECA-5529B701E8E3}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Cake.Issues.Reporting.Generic.Tests</RootNamespace>
-    <AssemblyName>Cake.Issues.Reporting.Generic.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-    <TargetFrameworkProfile />
+    <TargetFrameworks>net461</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <Description>Tests for the Cake.Issues.Reporting.Generic addin</Description>
+    <Copyright>Copyright © Pascal Berger and contributors</Copyright>
+    <Product>Cake.Issues</Product>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+
+  <PropertyGroup>
     <CodeAnalysisRuleSet>..\Cake.Issues.Reporting.Generic.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>..\Cake.Issues.Reporting.Generic.Tests.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.33.0" />
-    <PackageReference Include="Cake.Issues" Version="0.8.0" />
-    <PackageReference Include="Cake.Issues.Testing" Version="0.8.0" />
+    <EmbeddedResource Include="Templates\TestTemplate.cshtml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Cake.Testing" Version="0.33.0" />
+    <PackageReference Include="Cake.Issues.Testing" Version="0.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.17" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
@@ -52,32 +33,9 @@
       <Version>2.4.1</Version>
     </PackageReference>
   </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Reporting.Generic\Cake.Issues.Reporting.Generic.csproj">
-      <Project>{b514788a-8596-41ca-92b6-86199549dc2a}</Project>
-      <Name>Cake.Issues.Reporting.Generic</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Cake.Issues.Reporting.Generic\Cake.Issues.Reporting.Generic.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ColumnSortOrderExtensionsTests.cs" />
-    <Compile Include="DevExtremeThemeExtensionsTests.cs" />
-    <Compile Include="ExceptionAssertExtensions.cs" />
-    <Compile Include="IdeIntegrationSettingsTests.cs" />
-    <Compile Include="HtmlDxDataGridColumnDescriptionTests.cs" />
-    <Compile Include="IIssueExtensionsTests.cs" />
-    <Compile Include="UriExtensionsTests.cs" />
-    <Compile Include="FileLinkSettingsTests.cs" />
-    <Compile Include="GenericIssueReportFixture.cs" />
-    <Compile Include="GenericIssueReportFormatSettingsExtensionsTests.cs" />
-    <Compile Include="GenericIssueReportFormatSettingsTests.cs" />
-    <Compile Include="HtmlDxDataGridTemplateTests.cs" />
-    <Compile Include="GenericIssueReportGeneratorTests.cs" />
-    <Compile Include="GenericIssueReportTemplateExtensionsTests.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ViewBagHelperTests.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Templates\TestTemplate.cshtml" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
 </Project>

--- a/src/Cake.Issues.Reporting.Generic.Tests/Properties/AssemblyInfo.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/Properties/AssemblyInfo.cs
@@ -1,17 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Cake.Issues.Reporting.Generic.Tests")]
-[assembly: AssemblyDescription("Tests for the Cake.Issues.Reporting.Generic addin")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Cake.Issues")]
-[assembly: AssemblyCopyright("Copyright © Pascal Berger and contributors")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
@@ -20,16 +7,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("1e92a970-e905-4df8-8eca-5529b701e8e3")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Cake.Issues.Reporting.Generic/Cake.Issues.Reporting.Generic.csproj
+++ b/src/Cake.Issues.Reporting.Generic/Cake.Issues.Reporting.Generic.csproj
@@ -1,42 +1,33 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{B514788A-8596-41CA-92B6-86199549DC2A}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Cake.Issues.Reporting.Generic</RootNamespace>
-    <AssemblyName>Cake.Issues.Reporting.Generic</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-    <TargetFrameworkProfile />
+    <TargetFrameworks>net461</TargetFrameworks>
+    <Description>Support for creating issue reports in any text based format (HTML, Markdown, ...) from the Cake.Issues Addin for Cake Build Automation System</Description>
+    <Copyright>Copyright © Pascal Berger and contributors</Copyright>
+    <Product>Cake.Issues</Product>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
+
+  <PropertyGroup>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\Cake.Issues.Reporting.Generic.xml</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
     <CodeAnalysisRuleSet>..\Cake.Issues.Reporting.Generic.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\Cake.Issues.Reporting.Generic.xml</DocumentationFile>
-    <CodeAnalysisRuleSet>..\Cake.Issues.Reporting.Generic.ruleset</CodeAnalysisRuleSet>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net461|AnyCPU'">
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.Reporting.Generic.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net461|AnyCPU'">
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.Reporting.Generic.xml</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
+    <EmbeddedResource Include="Templates\DataTable.cshtml" />
+    <EmbeddedResource Include="Templates\Diagnostic.cshtml" />
+    <EmbeddedResource Include="Templates\DxDataGrid.cshtml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Cake.Core" Version="0.33.0" />
     <PackageReference Include="Cake.Issues" Version="0.8.0" />
     <PackageReference Include="Cake.Issues.Reporting" Version="0.8.0" />
@@ -50,159 +41,5 @@
       <Version>1.1.118</Version>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ColumnSortOrder.cs" />
-    <Compile Include="ColumnSortOrderExtensions.cs" />
-    <Compile Include="DevExtremeTheme.cs" />
-    <Compile Include="DevExtremeThemeExtensions.cs" />
-    <Compile Include="FileLinkSettings.cs" />
-    <Compile Include="HtmlDxDataGridColumnDescription.cs" />
-    <Compile Include="HtmlDxDataGridOption.cs" />
-    <Compile Include="GenericIssueReportFormatAliases.cs" />
-    <Compile Include="GenericIssueReportFormatSettingsExtensions.cs" />
-    <Compile Include="GenericIssueReportGenerator.cs" />
-    <Compile Include="GenericIssueReportFormatSettings.cs" />
-    <Compile Include="IdeIntegrationSettings.cs" />
-    <Compile Include="IIssueExtensions.cs" />
-    <Compile Include="ReportColumn.cs" />
-    <Compile Include="UriExtensions.cs" />
-    <Compile Include="ViewBagHelper.cs" />
-    <Compile Include="RazorEngineReferenceResolver.cs" />
-    <Compile Include="GenericIssueReportTemplate.cs" />
-    <Compile Include="GenericIssueReportTemplateExtensions.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Templates\Diagnostic.cshtml" />
-    <EmbeddedResource Include="Templates\DataTable.cshtml" />
-    <EmbeddedResource Include="Templates\DxDataGrid.cshtml" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.1\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.1\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" />
-  <Import Project="..\packages\Microsoft.NetFramework.Analyzers.2.9.1\build\Microsoft.NetFramework.Analyzers.props" Condition="Exists('..\packages\Microsoft.NetFramework.Analyzers.2.9.1\build\Microsoft.NetFramework.Analyzers.props')" />
-  <Import Project="..\packages\Microsoft.NetCore.Analyzers.2.9.1\build\Microsoft.NetCore.Analyzers.props" Condition="Exists('..\packages\Microsoft.NetCore.Analyzers.2.9.1\build\Microsoft.NetCore.Analyzers.props')" />
-  <Import Project="..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\build\Microsoft.CodeQuality.Analyzers.props" Condition="Exists('..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\build\Microsoft.CodeQuality.Analyzers.props')" />
-  <Import Project="..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" />
-  <Import Project="..\packages\Text.Analyzers.2.6.3\build\Text.Analyzers.props" Condition="Exists('..\packages\Text.Analyzers.2.6.3\build\Text.Analyzers.props')" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{B514788A-8596-41CA-92B6-86199549DC2A}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Cake.Issues.Reporting.Generic</RootNamespace>
-    <AssemblyName>Cake.Issues.Reporting.Generic</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\Cake.Issues.Reporting.Generic.xml</DocumentationFile>
-    <CodeAnalysisRuleSet>..\Cake.Issues.Reporting.Generic.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\Cake.Issues.Reporting.Generic.xml</DocumentationFile>
-    <CodeAnalysisRuleSet>..\Cake.Issues.Reporting.Generic.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.33.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.33.0\lib\net46\Cake.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Cake.Issues, Version=0.7.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Issues.0.7.0-beta0002\lib\netstandard2.0\Cake.Issues.dll</HintPath>
-    </Reference>
-    <Reference Include="Cake.Issues.Reporting, Version=0.7.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Issues.Reporting.0.7.0-beta0001\lib\netstandard2.0\Cake.Issues.Reporting.dll</HintPath>
-    </Reference>
-    <Reference Include="RazorEngine, Version=3.10.0.0, Culture=neutral, PublicKeyToken=9ee697374c7e744a, processorArchitecture=MSIL">
-      <HintPath>..\packages\RazorEngine.3.10.0\lib\net45\RazorEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.7\lib\net45\System.Web.Razor.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ColumnSortOrder.cs" />
-    <Compile Include="ColumnSortOrderExtensions.cs" />
-    <Compile Include="DevExtremeTheme.cs" />
-    <Compile Include="DevExtremeThemeExtensions.cs" />
-    <Compile Include="FileLinkSettings.cs" />
-    <Compile Include="HtmlDxDataGridColumnDescription.cs" />
-    <Compile Include="HtmlDxDataGridOption.cs" />
-    <Compile Include="GenericIssueReportFormatAliases.cs" />
-    <Compile Include="GenericIssueReportFormatSettingsExtensions.cs" />
-    <Compile Include="GenericIssueReportGenerator.cs" />
-    <Compile Include="GenericIssueReportFormatSettings.cs" />
-    <Compile Include="IdeIntegrationSettings.cs" />
-    <Compile Include="IIssueExtensions.cs" />
-    <Compile Include="ReportColumn.cs" />
-    <Compile Include="UriExtensions.cs" />
-    <Compile Include="ViewBagHelper.cs" />
-    <Compile Include="RazorEngineReferenceResolver.cs" />
-    <Compile Include="GenericIssueReportTemplate.cs" />
-    <Compile Include="GenericIssueReportTemplateExtensions.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Templates\Diagnostic.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
-    <EmbeddedResource Include="Templates\DataTable.cshtml" />
-    <EmbeddedResource Include="Templates\DxDataGrid.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\analyzers\dotnet\Microsoft.CodeAnalysis.VersionCheckAnalyzer.dll" />
-    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\analyzers\dotnet\cs\Humanizer.dll" />
-    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.CodeQuality.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.CodeQuality.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.NetCore.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.NetCore.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.NetCore.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.NetCore.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.NetFramework.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.NetFramework.Analyzers.2.9.1\analyzers\dotnet\cs\Microsoft.NetFramework.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
-    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
-    <Analyzer Include="..\packages\Text.Analyzers.2.6.3\analyzers\dotnet\cs\Text.Analyzers.dll" />
-    <Analyzer Include="..\packages\Text.Analyzers.2.6.3\analyzers\dotnet\cs\Text.CSharp.Analyzers.dll" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Text.Analyzers.2.6.3\build\Text.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Text.Analyzers.2.6.3\build\Text.Analyzers.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.1\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\build\Microsoft.CodeQuality.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeQuality.Analyzers.2.9.1\build\Microsoft.CodeQuality.Analyzers.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.NetCore.Analyzers.2.9.1\build\Microsoft.NetCore.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NetCore.Analyzers.2.9.1\build\Microsoft.NetCore.Analyzers.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.NetFramework.Analyzers.2.9.1\build\Microsoft.NetFramework.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NetFramework.Analyzers.2.9.1\build\Microsoft.NetFramework.Analyzers.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.1\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.1\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props'))" />
-  </Target> -->
+
 </Project>

--- a/src/Cake.Issues.Reporting.Generic/Properties/AssemblyInfo.cs
+++ b/src/Cake.Issues.Reporting.Generic/Properties/AssemblyInfo.cs
@@ -1,19 +1,6 @@
 ﻿using System;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Cake.Issues.Reporting.Generic")]
-[assembly: AssemblyDescription("Support for creating issue reports in any text based format (HTML, Markdown, ...) from the Cake.Issues Addin for Cake Build Automation System")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Cake.Issues")]
-[assembly: AssemblyCopyright("Copyright © Pascal Berger and contributors")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
@@ -22,19 +9,6 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b514788a-8596-41ca-92b6-86199549dc2a")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
 
 [assembly: CLSCompliant(true)]
 [assembly: InternalsVisibleTo("Cake.Issues.Reporting.Generic.Tests")]


### PR DESCRIPTION
Regarding support for .NET Standard (#3)
Here's a multitarget build using the new project format, targeting:
- dotnet 4.6.1 (dotnetstandard2.0 compat)
- dotnet standard 2.0
- dotnet coreapp 2.0
These allow both frameworks to coexist, and coreapp is required to allow for testing in xUnit (can't use dotnetstandard2.0 in xUnit).  These target frameworks seem the most stable choice, but let me know if other targets are more appropriate.  

A few notes
- This will build and package, but won't "work" for dotnetcore - RazorEngine only supports the older framework.   Another PR will be needed to add another engine e.g. RazorLight with dotnetcore support.
- While xUnit tests "work", looks like it's only the first target they're testing.  This is somewhat advantageous, as tests would fail for dotnetcore anyway.  Needs further fixing work when dotnetcore lib support implemented.
- Includes ignores for a bunch of FxCop/analysers related warnings that should probably be fixed later.
- Leaves packaging to the older nuspec setup rather than dotnet pack.  Advantage to using dotnet pack is it would allow you to eventually build the library cross platform, but also auto management of dependencies into the package meta.  Unsure however how the new pack handles older libs, would require tweaking the cake recipe.

Fixes #242