### PR TITLE
Skip package version check for integration tests

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -50,7 +50,8 @@ Task("Build-Demo-Reports")
         {
             Arguments = new Dictionary<string, string>
             {
-                { "verbosity", Context.Log.Verbosity.ToString("F") }
+                { "verbosity", Context.Log.Verbosity.ToString("F") },
+                { "settings_skippackageversioncheck", "true" }
             }
         });
 });


### PR DESCRIPTION
Skip package version check for integration tests, since it is by design that latest pre-release versions of all addins are used.