### PR TITLE
Use separate bootstrapping for building and testing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,8 +40,11 @@ jobs:
     inputs:
       sourceFolder: $(Pipeline.Workspace)/NuGet Package
       targetFolder: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
+    displayName: 'Copy build artifact for test run'
+  - powershell: ./build.ps1 -target Prepare-Build-Demo-Reports
     displayName: 'Prepare build artifact for test run'
-  - powershell: ./build.ps1 -target Build-Demo-Reports
+  - powershell: ./build.ps1
+    workingDirectory: ./demos/
     displayName: 'Run integration tests'
 # Integration Tests macOS 10.14 (.NET Framework runner)
 - job: Test_macOS_DotNetFramework
@@ -69,7 +72,11 @@ jobs:
     inputs:
       sourceFolder: $(Pipeline.Workspace)/NuGet Package
       targetFolder: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
+    displayName: 'Copy build artifact for test run'
+  - bash: |
+      ./build.sh --target Prepare-Build-Demo-Reports
     displayName: 'Prepare build artifact for test run'
   - bash: |
-      ./build.sh --target Build-Demo-Reports
+      ./build.sh
+    workingDirectory: ./demos/
     displayName: 'Run integration tests'

--- a/demos/build.cake
+++ b/demos/build.cake
@@ -4,7 +4,7 @@
 #addin "Cake.Issues.InspectCode&prerelease"
 #addin "Cake.Issues.Reporting&prerelease"
 
-#reference "./tools/Addins/Cake.Issues.Reporting.Generic/lib/net461/Cake.Issues.Reporting.Generic.dll"
+#reference "../BuildArtifacts/temp/Cake.Issues.Reporting.Generic/lib/net461/Cake.Issues.Reporting.Generic.dll"
 
 #load build/build/build.cake
 #load build/analyze/analyze.cake

--- a/demos/build.sh
+++ b/demos/build.sh
@@ -17,7 +17,7 @@ CAKE_EXE=$TOOLS_DIR/Cake.$CAKE_VERSION/Cake.exe
 export CAKE_SETTINGS_SKIPVERIFICATION='true'
 
 # Define default arguments.
-SCRIPT="recipe.cake"
+SCRIPT="build.cake"
 TARGET="Default"
 CONFIGURATION="Release"
 VERBOSITY="verbose"
@@ -100,4 +100,4 @@ fi
 ###########################################################################
 
 # Start Cake
-(exec mono "$CAKE_EXE" $SCRIPT --bootstrap) && (exec mono "$CAKE_EXE" $SCRIPT --verbosity=$VERBOSITY --configuration=$CONFIGURATION --target=$TARGET $DRYRUN "${SCRIPT_ARGUMENTS[@]}")
+exec mono "$CAKE_EXE" $SCRIPT --verbosity=$VERBOSITY --configuration=$CONFIGURATION --target=$TARGET $DRYRUN "${SCRIPT_ARGUMENTS[@]}"

--- a/recipe.cake
+++ b/recipe.cake
@@ -24,12 +24,12 @@ ToolSettings.SetToolSettings(
     testCoverageExcludeByAttribute: "*.ExcludeFromCodeCoverage*",
     testCoverageExcludeByFile: "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs");
 
-Task("Build-Demo-Reports")
+Task("Prepare-Build-Demo-Reports")
     .Does<BuildVersion>((context, buildVersion) =>
 {
     var package =
         BuildParameters.Paths.Directories.NuGetPackages.CombineWithFilePath("Cake.Issues.Reporting.Generic." + buildVersion.SemVersion + ".nupkg");
-    var addinDir = MakeAbsolute(Directory("./demos/tools/Addins/Cake.Issues.Reporting.Generic"));
+    var addinDir = BuildParameters.Paths.Directories.TempBuild.Combine("Cake.Issues.Reporting.Generic");
 
     if (DirectoryExists(addinDir))
     {
@@ -43,16 +43,6 @@ Task("Build-Demo-Reports")
     }
 
     Unzip(package, addinDir);
-
-    CakeExecuteScript(
-        "./demos/build.cake",
-        new CakeSettings
-        {
-            Arguments = new Dictionary<string, string>
-            {
-                { "verbosity", Context.Log.Verbosity.ToString("F") }
-            }
-        });
 });
 
 Build.Run();


### PR DESCRIPTION
Use separate bootstrapping for building and testing to make it possible to use different versions of Cake or runners for tests which are not supported by build script yet.