### PR TITLE
Use #addin preprocessor directive for integration tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ build_script:
 
 # Tests
 test_script:
-  - ps: .\build.ps1 -Target Build-Demo-Reports
+  - ps: .\demos\build.ps1
 
 # Tests
 test: off

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,8 +41,6 @@ jobs:
       sourceFolder: $(Pipeline.Workspace)/NuGet Package
       targetFolder: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
     displayName: 'Copy build artifact for test run'
-  - powershell: ./build.ps1 -target Prepare-Build-Demo-Reports
-    displayName: 'Prepare build artifact for test run'
   - powershell: ./build.ps1
     workingDirectory: ./demos/
     displayName: 'Run integration tests'
@@ -73,9 +71,6 @@ jobs:
       sourceFolder: $(Pipeline.Workspace)/NuGet Package
       targetFolder: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
     displayName: 'Copy build artifact for test run'
-  - bash: |
-      ./build.sh --target Prepare-Build-Demo-Reports
-    displayName: 'Prepare build artifact for test run'
   - bash: |
       ./build.sh
     workingDirectory: ./demos/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
       sourceFolder: $(Pipeline.Workspace)/NuGet Package
       targetFolder: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
     displayName: 'Copy build artifact for test run'
-  - powershell: ./build.ps1
+  - powershell: ./build.ps1 -verbosity diagnostic
     workingDirectory: ./demos/
     displayName: 'Run integration tests'
 # Integration Tests macOS 10.14 (.NET Framework runner)
@@ -72,6 +72,6 @@ jobs:
       targetFolder: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
     displayName: 'Copy build artifact for test run'
   - bash: |
-      ./build.sh
+      ./build.sh --verbosity diagnostic
     workingDirectory: ./demos/
     displayName: 'Run integration tests'

--- a/demos/build.cake
+++ b/demos/build.cake
@@ -3,8 +3,7 @@
 #addin "Cake.Issues.Markdownlint&prerelease"
 #addin "Cake.Issues.InspectCode&prerelease"
 #addin "Cake.Issues.Reporting&prerelease"
-
-#reference "../BuildArtifacts/temp/Cake.Issues.Reporting.Generic/lib/net461/Cake.Issues.Reporting.Generic.dll"
+#addin "Cake.Issues.Reporting.Generic&prerelease"
 
 #load build/build/build.cake
 #load build/analyze/analyze.cake

--- a/demos/nuget.config
+++ b/demos/nuget.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="Integration" value="../BuildArtifacts/Packages/NuGet" />
+    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+     <clear />
+  </disabledPackageSources>
+</configuration>

--- a/recipe.cake
+++ b/recipe.cake
@@ -24,25 +24,4 @@ ToolSettings.SetToolSettings(
     testCoverageExcludeByAttribute: "*.ExcludeFromCodeCoverage*",
     testCoverageExcludeByFile: "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs");
 
-Task("Prepare-Build-Demo-Reports")
-    .Does<BuildVersion>((context, buildVersion) =>
-{
-    var package =
-        BuildParameters.Paths.Directories.NuGetPackages.CombineWithFilePath("Cake.Issues.Reporting.Generic." + buildVersion.SemVersion + ".nupkg");
-    var addinDir = BuildParameters.Paths.Directories.TempBuild.Combine("Cake.Issues.Reporting.Generic");
-
-    if (DirectoryExists(addinDir))
-    {
-        DeleteDirectory(
-            addinDir,
-            new DeleteDirectorySettings 
-            {
-                Recursive = true,
-                Force = true
-            });
-    }
-
-    Unzip(package, addinDir);
-});
-
 Build.Run();


### PR DESCRIPTION
Use #addin preprocessor directive for integration tests instead of referencing the assemblies directly. This allows future scenarios in the future (like e.g. multi-targeting)