### PR TITLE
(build) Test pushing code coverage to codecov

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -11,7 +11,7 @@ BuildParameters.SetParameters(
     repositoryName: "Cake.Issues.Reporting.Generic",
     appVeyorAccountName: "cakecontrib",
     shouldGenerateDocumentation: false,
-    shouldRunCodecov: false,
+    shouldRunCodecov: true,
     shouldRunGitVersion: true);
 
 BuildParameters.PrintParameters(Context);


### PR DESCRIPTION
I want to rule out whether this is an issue with coveralls.net or
something else.

Running locally, all the code coverage reports looks good, so I am wondering if there is a problem with the publishing to coveralls, via coveralls.net.  I would like to test publishing the same reports to codecov to see what things look like there.