### PR TITLE
(GH-361) Create specific addin for Cake Frosting

### DIFF
--- a/nuspec/nuget/Cake.Frosting.Issues.Reporting.Generic.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.Reporting.Generic.nuspec
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>Cake.Frosting.Issues.Reporting.Generic</id>
+    <title>Cake.Frosting.Issues.Reporting.Generic</title>
+    <version>0.0.0</version>
+    <authors>Pascal Berger</authors>
+    <owners>pascalberger, cake-contrib</owners>
+    <summary>Support for creating any reports in any text based format (HTML, Markdown, ...) for the Cake.Issues addin for Cake Frosting</summary>
+    <description>
+The generic report support for the Cake.Issues addin for Cake Frosting allows you to create issue reports in any text format (HTML, Markdown, ...).
+
+This addin provides the aliases for any text based report format.
+It also requires the core Cake.Issues and Cake.Issues.Reporting addins and one or more issue providers.
+
+See the Project Site for an overview of the whole ecosystem of addins for working with issues in Cake scripts.
+
+NOTE:
+This is the version of the addin compatible with Cake Frosting.
+For addin compatible with Cake Script Runners see Cake.Issues.Reporting.Generic.
+    </description>
+    <license type="expression">MIT</license>
+    <projectUrl>https://cakeissues.net</projectUrl>
+    <icon>icon.png</icon>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <repository type="git" url="https://github.com/cake-contrib/Cake.Issues.Reporting.Generic.git"/>
+    <copyright>Copyright © Pascal Berger</copyright>
+    <tags>cake cake-issues cake-reportformat issues reporting html markdown razor</tags>
+    <releaseNotes>https://github.com/cake-contrib/Cake.Issues.Reporting.Generic/releases/tag/1.0.0</releaseNotes>
+    <dependencies>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Cake.Core" version="[1.0,2.0)" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues" version="1.0.0-beta0001" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues.Reporting" version="1.0.0-beta0001" exclude="Build,Analyzers" />
+        <dependency id="Gazorator" version="0.5.2" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="icon.png" target="" />
+    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\netstandard2.0\Cake.Issues.Reporting.Generic.dll" target="lib\netstandard2.0" />
+    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\netstandard2.0\Cake.Issues.Reporting.Generic.pdb" target="lib\netstandard2.0" />
+    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\netstandard2.0\Cake.Issues.Reporting.Generic.xml" target="lib\netstandard2.0" />
+  </files>
+</package>

--- a/nuspec/nuget/Cake.Issues.Reporting.Generic.nuspec
+++ b/nuspec/nuget/Cake.Issues.Reporting.Generic.nuspec
@@ -8,14 +8,16 @@
     <owners>pascalberger, cake-contrib</owners>
     <summary>Support for creating any reports in any text based format (HTML, Markdown, ...) for the Cake.Issues addin for Cake Build Automation System</summary>
     <description>
-The generic report support for the Cake.Issues addin for Cake allows you to create issue reports in any text format (HTML, Markdown, ...).
+The generic report support for the Cake.Issues addin for Cake Script Runners allows you to create issue reports in any text format (HTML, Markdown, ...).
 
 This addin provides the aliases for any text based report format.
 It also requires the core Cake.Issues and Cake.Issues.Reporting addins and one or more issue providers.
 
 See the Project Site for an overview of the whole ecosystem of addins for working with issues in Cake scripts.
 
-NOTE: This addin is currently not compatible with Cake Frosting.
+NOTE:
+This is the version of the addin compatible with Cake Script Runners.
+For addin compatible with Cake Frosting see Cake.Frosting.Issues.Reporting.Generic.
     </description>
     <license type="expression">MIT</license>
     <projectUrl>https://cakeissues.net</projectUrl>

--- a/src/Cake.Issues.Reporting.Generic/GenericIssueReportFormatAliases.cs
+++ b/src/Cake.Issues.Reporting.Generic/GenericIssueReportFormatAliases.cs
@@ -9,7 +9,8 @@
     /// <summary>
     /// Contains functionality for creating issue reports in any text based format (HTML, Markdown, ...).
     ///
-    /// NOTE: These aliases are currently not compatible with Cake Frosting.
+    /// NOTE: Use Cake.Issues.Reporting.Generic addin to use these aliases with Cake Script Runners and
+    /// Cake.Frosting.Issues.Reporting.Generic to use these aliases with Cake Frosting.
     /// </summary>
     [CakeAliasCategory(IssuesAliasConstants.MainCakeAliasCategory)]
     [SuppressMessage("ReSharper", "UnusedMember.Global", Justification = "Aliases are not used in addin code")]


### PR DESCRIPTION
Create specific addin for Cake Frosting which has dependencies defined instead of bundling required assemblies. 

Fixes #361