### PR TITLE
Make sure assembly for Linq is loaded when running in Cake Frosting

### DIFF
--- a/src/Cake.Issues.Reporting.Generic/GenericIssueReportGenerator.cs
+++ b/src/Cake.Issues.Reporting.Generic/GenericIssueReportGenerator.cs
@@ -40,6 +40,7 @@
                         .WithOutput(streamWriter)
                         .WithModel(issues)
                         .WithReferences(
+                            typeof(System.Linq.Enumerable).Assembly,
                             typeof(Cake.Issues.IIssue).Assembly,
                             typeof(Cake.Issues.Reporting.IIssueReportFormat).Assembly,
                             typeof(Cake.Issues.Reporting.Generic.DevExtremeTheme).Assembly,


### PR DESCRIPTION
When running under Cake Frosting assembly for Linq is not loaded automatically. We therefore need to make sure that it is loaded and available for the templates when running in Cake Frosting.