### PR TITLE
(GH-424) Multi-Target .NET Core 3.1, 5, & 6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 #---------------------------------#
 #  Build Image                    #
 #---------------------------------#
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 environment:
   MYGET_SOURCE:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,43 +13,16 @@ jobs:
 # Build
 - job: Build
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'windows-2022'
   steps:
   - powershell: ./build.ps1
     displayName: 'Build'
   - publish: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
     artifact: NuGet Package
     displayName: 'Publish NuGet package as build artifact'
-# Integration Tests Windows (.NET Framework)
-- job: Test_Windows_DotNetFramework
-  displayName: 'Integration Tests Windows (.NET Framework)'
-  dependsOn: Build
-  pool:
-    vmImage: 'windows-2019'
-  steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '14.x'
-    displayName: 'Install NodeJs 14.x'
-  - powershell: choco install markdownlint-cli --no-progress
-    displayName: 'Install required tools'
-  - download: current
-    artifact: NuGet Package
-    displayName: 'Download build artifact'
-  - task: CopyFiles@2
-    inputs:
-      sourceFolder: $(Pipeline.Workspace)/NuGet Package
-      targetFolder: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
-    displayName: 'Copy build artifact for test run'
-  - powershell: ./build.ps1 --verbosity=diagnostic
-    workingDirectory: ./demos/script-runner/
-    displayName: 'Run integration tests'
-  - publish: $(Build.SourcesDirectory)/docs/templates
-    artifact: Integration Tests Windows (.NET Framework)
-    displayName: 'Publish generated reports as build artifact'
-# Integration Tests Windows (.NET Core tool)
-- job: Test_Windows_DotNetCoreTool
-  displayName: Integration Tests Windows (.NET Core tool)
+# Integration Tests Windows Server 2019 (.NET Core tool)
+- job: Test_Windows_2019_DotNetCoreTool
+  displayName: Integration Tests Windows Server 2019 (.NET Core tool)
   dependsOn: Build
   pool:
     vmImage: 'windows-2019'
@@ -75,11 +48,41 @@ jobs:
     workingDirectory: ./demos/script-runner/
     displayName: 'Run integration tests'
   - publish: $(Build.SourcesDirectory)/docs/templates
-    artifact: Integration Tests Windows (.NET Core tool)
+    artifact: Integration Tests Windows Server 2019 (.NET Core tool)
     displayName: 'Publish generated reports as build artifact'
-# Integration Tests Windows 2019 (Frosting)
+# Integration Tests Windows Server 2022 (.NET Core tool)
+- job: Test_Windows_2022_DotNetCoreTool
+  displayName: Integration Tests Windows Server 2022 (.NET Core tool)
+  dependsOn: Build
+  pool:
+    vmImage: 'windows-2022'
+  steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '14.x'
+    displayName: 'Install NodeJs 14.x'
+  - powershell: choco install markdownlint-cli --no-progress
+    displayName: 'Install required tools'
+  - download: current
+    artifact: NuGet Package
+    displayName: 'Download build artifact'
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Pipeline.Workspace)/NuGet Package
+      targetFolder: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
+    displayName: 'Copy build artifact for test run'
+  - powershell: dotnet tool restore
+    workingDirectory: ./demos/script-runner/
+    displayName: 'Restore .NET Core tool'
+  - powershell: dotnet cake
+    workingDirectory: ./demos/script-runner/
+    displayName: 'Run integration tests'
+  - publish: $(Build.SourcesDirectory)/docs/templates
+    artifact: Integration Tests Windows Server 2022 (.NET Core tool)
+    displayName: 'Publish generated reports as build artifact'
+# Integration Tests Windows Server 2019 (Frosting)
 - job: Test_Windows_2019_Frosting
-  displayName: Integration Tests Windows 2019 (Frosting)
+  displayName: Integration Tests Windows Server 2019 (Frosting)
   dependsOn: Build
   pool:
     vmImage: 'windows-2019'
@@ -106,27 +109,25 @@ jobs:
     workingDirectory: ./demos/frosting/
     displayName: 'Run integration tests'
   - publish: $(Build.SourcesDirectory)/docs/templates
-    artifact: Integration Tests Windows 2019 (Frosting)
+    artifact: Integration Tests Windows Server 2019 (Frosting)
     displayName: 'Publish generated reports as build artifact'
-# Integration Tests macOS 10.14 (Mono)
-- job: Test_macOS_Mono
-  displayName: 'Integration Tests macOS 10.14 (Mono)'
+# Integration Tests Windows Server 2022 (Frosting)
+- job: Test_Windows_2022_Frosting
+  displayName: Integration Tests Windows Server 2022 (Frosting)
   dependsOn: Build
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'windows-2022'
   steps:
   - task: NodeTool@0
     inputs:
       versionSpec: '14.x'
     displayName: 'Install NodeJs 14.x'
-  - bash: |
-      npm install -g markdownlint-cli
+  - powershell: choco install markdownlint-cli --no-progress
     displayName: 'Install required tools'
-  # To manually select a Xamarin SDK version on the Hosted macOS agent, enable this script with the SDK version you want to target
-  #  https://go.microsoft.com/fwlink/?linkid=871629
-  - bash: |
-      sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 5_18_1
-    displayName: 'Select Mono 5.18.1'
+  - task: DeleteFiles@1
+    inputs:
+      Contents: 'docs/templates/*.html'
+      displayName: 'Cleanup reports'
   - download: current
     artifact: NuGet Package
     displayName: 'Download build artifact'
@@ -135,15 +136,14 @@ jobs:
       sourceFolder: $(Pipeline.Workspace)/NuGet Package
       targetFolder: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
     displayName: 'Copy build artifact for test run'
-  - bash: |
-      ./build.sh --verbosity=diagnostic
-    workingDirectory: ./demos/script-runner/
+  - powershell: ./build.ps1 --verbosity=diagnostic
+    workingDirectory: ./demos/frosting/
     displayName: 'Run integration tests'
   - publish: $(Build.SourcesDirectory)/docs/templates
-    artifact: Integration Tests macOS 10.14 (Mono)
+    artifact: Integration Tests Windows Server 2022 (Frosting)
     displayName: 'Publish generated reports as build artifact'
 # Integration Tests macOS 10.15 (.NET Core tool)
-- job: Test_macOS_DotNetCoreTool
+- job: Test_macOS_10_15_DotNetCoreTool
   displayName: Integration Tests macOS 10.15 (.NET Core tool)
   dependsOn: Build
   pool:
@@ -204,37 +204,8 @@ jobs:
   - publish: $(Build.SourcesDirectory)/docs/templates
     artifact: Integration Tests macOS 10.15 (Frosting)
     displayName: 'Publish generated reports as build artifact'
-# Integration Tests Ubuntu 18.04 (Mono)
-- job: Test_ubuntu_Mono
-  displayName: 'Integration Tests Ubuntu 18.04 (Mono)'
-  dependsOn: Build
-  pool:
-    vmImage: 'ubuntu-18.04'
-  steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '14.x'
-    displayName: 'Install NodeJs 14.x'
-  - bash: |
-      npm install -g markdownlint-cli
-    displayName: 'Install required tools'
-  - download: current
-    artifact: NuGet Package
-    displayName: 'Download build artifact'
-  - task: CopyFiles@2
-    inputs:
-      sourceFolder: $(Pipeline.Workspace)/NuGet Package
-      targetFolder: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
-    displayName: 'Copy build artifact for test run'
-  - bash: |
-      ./build.sh --verbosity=diagnostic
-    workingDirectory: ./demos/script-runner/
-    displayName: 'Run integration tests'
-  - publish: $(Build.SourcesDirectory)/docs/templates
-    artifact: Integration Tests Ubuntu 16.04 (Mono)
-    displayName: 'Publish generated reports as build artifact'
-# Integration Tests Ubuntu 16.04 (.NET Core tool)
-- job: Test_ubuntu_DotNetCoreTool
+# Integration Tests Ubuntu 18.04 (.NET Core tool)
+- job: Test_Ubuntu_18_04_DotNetCoreTool
   displayName: Integration Tests Ubuntu 18.04 (.NET Core tool)
   dependsOn: Build
   pool:
@@ -264,9 +235,42 @@ jobs:
     workingDirectory: ./demos/script-runner/
     displayName: 'Run integration tests'
   - publish: $(Build.SourcesDirectory)/docs/templates
-    artifact: Integration Tests Ubuntu 16.04 (.NET Core tool)
+    artifact: Integration Tests Ubuntu 18.04 (.NET Core tool)
     displayName: 'Publish generated reports as build artifact'
-# Integration Tests Ubuntu 16.04 (Frosting)
+# Integration Tests Ubuntu 20.04 (.NET Core tool)
+- job: Test_Ubuntu_20_04_DotNetCoreTool
+  displayName: Integration Tests Ubuntu 20.04 (.NET Core tool)
+  dependsOn: Build
+  pool:
+    vmImage: 'ubuntu-20.04'
+  steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '14.x'
+    displayName: 'Install NodeJs 14.x'
+  - bash: |
+      npm install -g markdownlint-cli
+    displayName: 'Install required tools'
+  - download: current
+    artifact: NuGet Package
+    displayName: 'Download build artifact'
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Pipeline.Workspace)/NuGet Package
+      targetFolder: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
+    displayName: 'Copy build artifact for test run'
+  - bash: |
+      dotnet tool restore
+    workingDirectory: ./demos/script-runner/
+    displayName: 'Restore .NET Core tool'
+  - bash: |
+      dotnet cake
+    workingDirectory: ./demos/script-runner/
+    displayName: 'Run integration tests'
+  - publish: $(Build.SourcesDirectory)/docs/templates
+    artifact: Integration Tests Ubuntu 20.04 (.NET Core tool)
+    displayName: 'Publish generated reports as build artifact'
+# Integration Tests Ubuntu 18.04 (Frosting)
 - job: Test_Ubuntu_18_04_Frosting
   displayName: Integration Tests Ubuntu 18.04 (Frosting)
   dependsOn: Build
@@ -293,5 +297,34 @@ jobs:
     workingDirectory: ./demos/frosting/
     displayName: 'Run integration tests'
   - publish: $(Build.SourcesDirectory)/docs/templates
-    artifact: Integration Tests Ubuntu 16.04 (Frosting)
+    artifact: Integration Tests Ubuntu 18.04 (Frosting)
+    displayName: 'Publish generated reports as build artifact'
+# Integration Tests Ubuntu 20.04 (Frosting)
+- job: Test_Ubuntu_20_04_Frosting
+  displayName: Integration Tests Ubuntu 20.04 (Frosting)
+  dependsOn: Build
+  pool:
+    vmImage: 'ubuntu-20.04'
+  steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '14.x'
+    displayName: 'Install NodeJs 14.x'
+  - bash: |
+      npm install -g markdownlint-cli
+    displayName: 'Install required tools'
+  - download: current
+    artifact: NuGet Package
+    displayName: 'Download build artifact'
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Pipeline.Workspace)/NuGet Package
+      targetFolder: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
+    displayName: 'Copy build artifact for test run'
+  - bash: |
+      ./build.sh --verbosity=diagnostic
+    workingDirectory: ./demos/frosting/
+    displayName: 'Run integration tests'
+  - publish: $(Build.SourcesDirectory)/docs/templates
+    artifact: Integration Tests Ubuntu 20.04 (Frosting)
     displayName: 'Publish generated reports as build artifact'

--- a/nuspec/nuget/Cake.Frosting.Issues.Reporting.Generic.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.Reporting.Generic.nuspec
@@ -28,7 +28,19 @@ For addin compatible with Cake Script Runners see Cake.Issues.Reporting.Generic.
     <tags>cake cake-addin cake-issues cake-reportformat issues reporting html markdown razor</tags>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues.Reporting.Generic/releases/tag/1.0.0</releaseNotes>
     <dependencies>
-      <group targetFramework=".NETStandard2.0">
+      <group targetFramework="netcoreapp3.1">
+        <dependency id="Cake.Core" version="[1.0,2.0)" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues" version="[1.0,2.0)" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues.Reporting" version="[1.0,2.0)" exclude="Build,Analyzers" />
+        <dependency id="Gazorator" version="0.5.2" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net5.0">
+        <dependency id="Cake.Core" version="[1.0,2.0)" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues" version="[1.0,2.0)" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues.Reporting" version="[1.0,2.0)" exclude="Build,Analyzers" />
+        <dependency id="Gazorator" version="0.5.2" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net6.0">
         <dependency id="Cake.Core" version="[1.0,2.0)" exclude="Build,Analyzers" />
         <dependency id="Cake.Issues" version="[1.0,2.0)" exclude="Build,Analyzers" />
         <dependency id="Cake.Issues.Reporting" version="[1.0,2.0)" exclude="Build,Analyzers" />
@@ -38,8 +50,14 @@ For addin compatible with Cake Script Runners see Cake.Issues.Reporting.Generic.
   </metadata>
   <files>
     <file src="icon.png" target="" />
-    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\netstandard2.0\Cake.Issues.Reporting.Generic.dll" target="lib\netstandard2.0" />
-    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\netstandard2.0\Cake.Issues.Reporting.Generic.pdb" target="lib\netstandard2.0" />
-    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\netstandard2.0\Cake.Issues.Reporting.Generic.xml" target="lib\netstandard2.0" />
+    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\netcoreapp3.1\Cake.Issues.Reporting.Generic.dll" target="lib\netcoreapp3.1" />
+    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\netcoreapp3.1\Cake.Issues.Reporting.Generic.pdb" target="lib\netcoreapp3.1" />
+    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\netcoreapp3.1\Cake.Issues.Reporting.Generic.xml" target="lib\netcoreapp3.1" />
+    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\net5.0\Cake.Issues.Reporting.Generic.dll" target="lib\net5.0" />
+    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\net5.0\Cake.Issues.Reporting.Generic.pdb" target="lib\net5.0" />
+    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\net5.0\Cake.Issues.Reporting.Generic.xml" target="lib\net5.0" />
+    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\net6.0\Cake.Issues.Reporting.Generic.dll" target="lib\net6.0" />
+    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\net6.0\Cake.Issues.Reporting.Generic.pdb" target="lib\net6.0" />
+    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\net6.0\Cake.Issues.Reporting.Generic.xml" target="lib\net6.0" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.Reporting.Generic.nuspec
+++ b/nuspec/nuget/Cake.Issues.Reporting.Generic.nuspec
@@ -31,9 +31,6 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.Reporting.Gener
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
     <file src="**\*.dll" target="lib" exclude="**\*CodeAnalysis*.dll;**\Cake.Core.dll;**\Cake.Issues.dll;**\Cake.Issues.Reporting.dll;**\System.*.dll" />
-    <file src="netstandard2.0\System.*.dll" target="lib\netstandard2.0" />
-    <!-- Cake ships Roslyn for .NET Core but not for .NET Framework runner -->
-    <file src="netstandard2.0\Microsoft.CodeAnalysis*.dll" target="lib\netstandard2.0" />
     <file src="**\Cake.Issues.Reporting.Generic.xml" target="lib" />
   </files>
 </package>

--- a/recipe.cake
+++ b/recipe.cake
@@ -23,4 +23,8 @@ ToolSettings.SetToolSettings(
     testCoverageExcludeByAttribute: "*.ExcludeFromCodeCoverage*",
     testCoverageExcludeByFile: "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs");
 
+// Workaround until https://github.com/cake-contrib/Cake.Recipe/issues/862 has been fixed in Cake.Recipe
+ToolSettings.SetToolPreprocessorDirectives(
+    reSharperTools: "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2021.2.0");
+
 Build.RunDotNetCore();

--- a/src/Cake.Issues.Reporting.Generic.Tests/Cake.Issues.Reporting.Generic.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Generic.Tests/Cake.Issues.Reporting.Generic.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Description>Tests for the Cake.Issues.Reporting.Generic addin</Description>
     <Copyright>Copyright © Pascal Berger and contributors</Copyright>

--- a/src/Cake.Issues.Reporting.Generic/Cake.Issues.Reporting.Generic.csproj
+++ b/src/Cake.Issues.Reporting.Generic/Cake.Issues.Reporting.Generic.csproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- net461 caused issues, while netstandard2.0 caused issues running .NET Core tool on macOS.
-    Therefore targeting netstandard2.0 for .NET Framework and netcoreappX for .NET Core -->
-    <TargetFrameworks>netstandard2.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>Support for creating issue reports in any text based format (HTML, Markdown, ...) from the Cake.Issues Addin for Cake Build Automation System</Description>
     <Copyright>Copyright © Pascal Berger and contributors</Copyright>
     <Product>Cake.Issues</Product>


### PR DESCRIPTION
Multi-Target .NET Core 3.1, 5, & 6 to follow best-practices for Cake 2.0.

Fixes #424 