### PR TITLE
Pin version of JetBrains tools

### DIFF
--- a/demos/script-runner/build.cake
+++ b/demos/script-runner/build.cake
@@ -7,7 +7,7 @@
 #addin "Cake.Issues.Reporting&prerelease"
 #addin "Cake.Issues.Reporting.Generic&prerelease"
 
-#tool "nuget:?package=JetBrains.ReSharper.CommandLineTools"
+#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2021.2.2
 
 #load build/build/build.cake
 #load build/analyze/analyze.cake


### PR DESCRIPTION
Pin version of JetBrains tools, since DupFinder is no longer available in newer versions.