### PR TITLE
Build against Cake 3.0 and update target frameworks

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,12 +7,21 @@ environment:
   MYGET_SOURCE:
 
 #---------------------------------#
-#  Build Script                   #
+#  Install .NET                   #
 #---------------------------------#
 install:
-  # Update to latest NuGet version since we require 5.3.0 for embedded icon
-  - ps: nuget update -self
+  - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
+  - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
+  - ps: Invoke-WebRequest -Uri "https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1" -OutFile "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1"
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 5.0.408 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 6.0.408 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 7.0.302 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
+  - ps: dotnet --info
 
+#---------------------------------#
+#  Build Script                   #
+#---------------------------------#
 build_script:
   - ps: .\build.ps1 --target=CI
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,16 @@ jobs:
   pool:
     vmImage: 'windows-2022'
   steps:
+  # .NET 5 required for GitVersion
+  - task: UseDotNet@2
+    inputs:
+      version: '5.x'
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+  - task: UseDotNet@2
+    inputs:
+      version: '7.x'
   - powershell: ./build.ps1
     displayName: 'Build'
   - publish: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,12 +19,15 @@ jobs:
   - task: UseDotNet@2
     inputs:
       version: '5.x'
+    displayName: 'Install .NET 5'
   - task: UseDotNet@2
     inputs:
       version: '6.x'
+    displayName: 'Install .NET 6'
   - task: UseDotNet@2
     inputs:
       version: '7.x'
+    displayName: 'Install .NET 7'
   - powershell: ./build.ps1
     displayName: 'Build'
   - publish: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
@@ -37,6 +40,10 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   steps:
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: NodeTool@0
     inputs:
       versionSpec: '14.x'
@@ -67,6 +74,10 @@ jobs:
   pool:
     vmImage: 'windows-2022'
   steps:
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: NodeTool@0
     inputs:
       versionSpec: '14.x'
@@ -97,6 +108,10 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   steps:
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: NodeTool@0
     inputs:
       versionSpec: '14.x'
@@ -128,6 +143,10 @@ jobs:
   pool:
     vmImage: 'windows-2022'
   steps:
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: NodeTool@0
     inputs:
       versionSpec: '14.x'
@@ -159,6 +178,10 @@ jobs:
   pool:
     vmImage: 'macOS-11'
   steps:
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: NodeTool@0
     inputs:
       versionSpec: '14.x'
@@ -192,6 +215,10 @@ jobs:
   pool:
     vmImage: 'macOS-13'
   steps:
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: NodeTool@0
     inputs:
       versionSpec: '14.x'
@@ -225,6 +252,10 @@ jobs:
   pool:
     vmImage: 'macOS-11'
   steps:
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: NodeTool@0
     inputs:
       versionSpec: '14.x'
@@ -254,6 +285,10 @@ jobs:
   pool:
     vmImage: 'macOS-13'
   steps:
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: NodeTool@0
     inputs:
       versionSpec: '14.x'
@@ -283,6 +318,10 @@ jobs:
   pool:
     vmImage: 'ubuntu-20.04'
   steps:
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: NodeTool@0
     inputs:
       versionSpec: '14.x'
@@ -316,6 +355,10 @@ jobs:
   pool:
     vmImage: 'ubuntu-22.04'
   steps:
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: NodeTool@0
     inputs:
       versionSpec: '14.x'
@@ -349,6 +392,10 @@ jobs:
   pool:
     vmImage: 'ubuntu-20.04'
   steps:
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: NodeTool@0
     inputs:
       versionSpec: '14.x'
@@ -378,6 +425,10 @@ jobs:
   pool:
     vmImage: 'ubuntu-22.04'
   steps:
+  - task: UseDotNet@2
+    inputs:
+      version: '6.x'
+    displayName: 'Install .NET 6'
   - task: NodeTool@0
     inputs:
       versionSpec: '14.x'

--- a/demos/frosting/build/Build.csproj
+++ b/demos/frosting/build/Build.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
   <ItemGroup>

--- a/demos/frosting/build/Build.csproj
+++ b/demos/frosting/build/Build.csproj
@@ -5,7 +5,7 @@
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" Version="2.0.0" />
+    <PackageReference Include="Cake.Frosting" Version="3.0.0" />
     <PackageReference Include="Cake.Frosting.Issues.Reporting.Generic" Version="*-*" />
   </ItemGroup>
 </Project>

--- a/demos/script-runner/.config/dotnet-tools.json
+++ b/demos/script-runner/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/demos/script-runner/build/build/build.cake
+++ b/demos/script-runner/build/build/build.cake
@@ -6,10 +6,10 @@ Task("Build")
     var msBuildLogFilePath = data.RepoRootFolder.CombineWithFilePath("msbuild.binlog");
 
 #if NETCOREAPP
-    DotNetCoreRestore(solutionFile.FullPath);
+    DotNetRestore(solutionFile.FullPath);
 
     var settings =
-        new DotNetCoreMSBuildSettings()
+        new DotNetMSBuildSettings()
             .WithTarget("Rebuild")
             .WithLogger(
                 "BinaryLogger," + Context.Tools.Resolve("Cake.Issues.MsBuild*/**/StructuredLogger.dll"),
@@ -17,9 +17,9 @@ Task("Build")
                 msBuildLogFilePath.FullPath
             );
 
-    DotNetCoreBuild(
+    DotNetBuild(
         solutionFile.FullPath,
-        new DotNetCoreBuildSettings
+        new DotNetBuildSettings
         {
             MSBuildSettings = settings
         });

--- a/demos/script-runner/tools/packages.config
+++ b/demos/script-runner/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="2.0.0" />
+    <package id="Cake" version="3.0.0" />
 </packages>

--- a/nuspec/nuget/Cake.Frosting.Issues.Reporting.Generic.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.Reporting.Generic.nuspec
@@ -29,15 +29,15 @@ For addin compatible with Cake Script Runners see Cake.Issues.Reporting.Generic.
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues.Reporting.Generic/releases/tag/2.0.0</releaseNotes>
     <dependencies>
       <group targetFramework="net6.0">
-        <dependency id="Cake.Core" version="2.0" exclude="Build,Analyzers" />
-        <dependency id="Cake.Issues" version="[2.0.0,3.0)" exclude="Build,Analyzers" />
-        <dependency id="Cake.Issues.Reporting" version="[2.0.0,3.0)" exclude="Build,Analyzers" />
+        <dependency id="Cake.Core" version="3.0" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues" version="[3.0.0-*,4.0)" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues.Reporting" version="[3.0.0-*,4.0)" exclude="Build,Analyzers" />
         <dependency id="Gazorator" version="0.5.2" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net7.0">
-        <dependency id="Cake.Core" version="2.0" exclude="Build,Analyzers" />
-        <dependency id="Cake.Issues" version="[2.0.0,3.0)" exclude="Build,Analyzers" />
-        <dependency id="Cake.Issues.Reporting" version="[2.0.0,3.0)" exclude="Build,Analyzers" />
+        <dependency id="Cake.Core" version="3.0" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues" version="[3.0.0-*,4.0)" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues.Reporting" version="[3.0.0-*,4.0)" exclude="Build,Analyzers" />
         <dependency id="Gazorator" version="0.5.2" exclude="Build,Analyzers" />
       </group>
     </dependencies>

--- a/nuspec/nuget/Cake.Frosting.Issues.Reporting.Generic.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.Reporting.Generic.nuspec
@@ -28,19 +28,13 @@ For addin compatible with Cake Script Runners see Cake.Issues.Reporting.Generic.
     <tags>cake cake-addin cake-issues cake-reportformat issues reporting html markdown razor</tags>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues.Reporting.Generic/releases/tag/2.0.0</releaseNotes>
     <dependencies>
-      <group targetFramework="netcoreapp3.1">
-        <dependency id="Cake.Core" version="2.0" exclude="Build,Analyzers" />
-        <dependency id="Cake.Issues" version="[2.0.0,3.0)" exclude="Build,Analyzers" />
-        <dependency id="Cake.Issues.Reporting" version="[2.0.0,3.0)" exclude="Build,Analyzers" />
-        <dependency id="Gazorator" version="0.5.2" exclude="Build,Analyzers" />
-      </group>
-      <group targetFramework="net5.0">
-        <dependency id="Cake.Core" version="2.0" exclude="Build,Analyzers" />
-        <dependency id="Cake.Issues" version="[2.0.0,3.0)" exclude="Build,Analyzers" />
-        <dependency id="Cake.Issues.Reporting" version="[2.0.0,3.0)" exclude="Build,Analyzers" />
-        <dependency id="Gazorator" version="0.5.2" exclude="Build,Analyzers" />
-      </group>
       <group targetFramework="net6.0">
+        <dependency id="Cake.Core" version="2.0" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues" version="[2.0.0,3.0)" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues.Reporting" version="[2.0.0,3.0)" exclude="Build,Analyzers" />
+        <dependency id="Gazorator" version="0.5.2" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net7.0">
         <dependency id="Cake.Core" version="2.0" exclude="Build,Analyzers" />
         <dependency id="Cake.Issues" version="[2.0.0,3.0)" exclude="Build,Analyzers" />
         <dependency id="Cake.Issues.Reporting" version="[2.0.0,3.0)" exclude="Build,Analyzers" />
@@ -50,14 +44,11 @@ For addin compatible with Cake Script Runners see Cake.Issues.Reporting.Generic.
   </metadata>
   <files>
     <file src="icon.png" target="" />
-    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\netcoreapp3.1\Cake.Issues.Reporting.Generic.dll" target="lib\netcoreapp3.1" />
-    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\netcoreapp3.1\Cake.Issues.Reporting.Generic.pdb" target="lib\netcoreapp3.1" />
-    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\netcoreapp3.1\Cake.Issues.Reporting.Generic.xml" target="lib\netcoreapp3.1" />
-    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\net5.0\Cake.Issues.Reporting.Generic.dll" target="lib\net5.0" />
-    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\net5.0\Cake.Issues.Reporting.Generic.pdb" target="lib\net5.0" />
-    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\net5.0\Cake.Issues.Reporting.Generic.xml" target="lib\net5.0" />
     <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\net6.0\Cake.Issues.Reporting.Generic.dll" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\net6.0\Cake.Issues.Reporting.Generic.pdb" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\net6.0\Cake.Issues.Reporting.Generic.xml" target="lib\net6.0" />
+    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\net7.0\Cake.Issues.Reporting.Generic.dll" target="lib\net7.0" />
+    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\net7.0\Cake.Issues.Reporting.Generic.pdb" target="lib\net7.0" />
+    <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\net7.0\Cake.Issues.Reporting.Generic.xml" target="lib\net7.0" />
   </files>
 </package>

--- a/src/Cake.Issues.Reporting.Generic.Tests/Cake.Issues.Reporting.Generic.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Generic.Tests/Cake.Issues.Reporting.Generic.Tests.csproj
@@ -29,8 +29,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Cake.Testing" Version="2.0.0" />
-    <PackageReference Include="Cake.Issues.Testing" Version="2.0.0" />
+    <PackageReference Include="Cake.Testing" Version="3.0.0" />
+    <PackageReference Include="Cake.Issues.Testing" Version="3.0.0-beta0001" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Cake.Issues.Reporting.Generic.Tests/Cake.Issues.Reporting.Generic.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Generic.Tests/Cake.Issues.Reporting.Generic.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Description>Tests for the Cake.Issues.Reporting.Generic addin</Description>
     <Copyright>Copyright © Pascal Berger and contributors</Copyright>

--- a/src/Cake.Issues.Reporting.Generic/Cake.Issues.Reporting.Generic.csproj
+++ b/src/Cake.Issues.Reporting.Generic/Cake.Issues.Reporting.Generic.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <Description>Support for creating issue reports in any text based format (HTML, Markdown, ...) from the Cake.Issues Addin for Cake Build Automation System</Description>
     <Copyright>Copyright © Pascal Berger and contributors</Copyright>
     <Product>Cake.Issues</Product>

--- a/src/Cake.Issues.Reporting.Generic/Cake.Issues.Reporting.Generic.csproj
+++ b/src/Cake.Issues.Reporting.Generic/Cake.Issues.Reporting.Generic.csproj
@@ -25,9 +25,9 @@
   <ItemGroup>
     <PackageReference Include="Gazorator" Version="0.5.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Cake.Core" Version="2.0.0" />
-    <PackageReference Include="Cake.Issues" Version="2.0.0" />
-    <PackageReference Include="Cake.Issues.Reporting" Version="2.0.0" />
+    <PackageReference Include="Cake.Core" Version="3.0.0" />
+    <PackageReference Include="Cake.Issues" Version="3.0.0-beta0001" />
+    <PackageReference Include="Cake.Issues.Reporting" Version="3.0.0-beta0001" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Builds against Cake 3.0, Cake Issues 3.0 Beta 1 and updates target frameworks to .NET 6 and .NET 7.

Fixes #477
Fixes #478 
Fixes #479 