### PR TITLE
HtmlDxDataGrid: Update jsPDF-AutoTable to 3.5.29

### DIFF
--- a/docs/templates/htmldxdatagrid-demo-exportformat-pdf.html
+++ b/docs/templates/htmldxdatagrid-demo-exportformat-pdf.html
@@ -11,7 +11,7 @@
 
     <script type="text/javascript" src="https://ajax.aspnetcdn.com/ajax/jquery/jquery-3.7.0.min.js"></script>
                 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-                <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.22/jspdf.plugin.autotable.min.js"></script>
+                <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.29/jspdf.plugin.autotable.min.js"></script>
     <link rel="stylesheet" type="text/css" href="https://cdn3.devexpress.com/jslib/22.2.6/css/dx.common.css" />
     <link rel="stylesheet" type="text/css" href="https://cdn3.devexpress.com/jslib/22.2.6/css/dx.light.css" />
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/22.2.6/js/dx.all.js"></script>

--- a/src/Cake.Issues.Reporting.Generic/HtmlDxDataGridOption.cs
+++ b/src/Cake.Issues.Reporting.Generic/HtmlDxDataGridOption.cs
@@ -482,7 +482,7 @@
         /// <summary>
         /// Version of <see href="https://github.com/simonbengtsson/jsPDF-AutoTable">jsPDF-AutoTable plugin</see> which should be used.
         /// This version needs to match the version required by the selected <see cref="DevExtremeVersion"/>.
-        /// Default value is <c>3.5.22</c>.
+        /// Default value is <c>3.5.29</c>.
         /// </summary>
         JsPdfAutotableVersion,
     }

--- a/src/Cake.Issues.Reporting.Generic/Templates/DxDataGrid.cshtml
+++ b/src/Cake.Issues.Reporting.Generic/Templates/DxDataGrid.cshtml
@@ -75,7 +75,7 @@
     string jsPdfVersion = ViewBagHelper.ValueOrDefault(ViewBag.FileSaverJsVersion, "2.5.1").Trim();
     string jsPdfAutoTableLocation = ViewBagHelper.ValueOrDefault(ViewBag.FileSaverJsLocation, "https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/").Trim();
     jsPdfAutoTableLocation = jsPdfAutoTableLocation.WithEnding("/");
-    string jsPdfAutoTableVersion = ViewBagHelper.ValueOrDefault(ViewBag.FileSaverJsVersion, "3.5.22").Trim();
+    string jsPdfAutoTableVersion = ViewBagHelper.ValueOrDefault(ViewBag.FileSaverJsVersion, "3.5.29").Trim();
     string devExtremeLocation = ViewBagHelper.ValueOrDefault(ViewBag.DevExtremeLocation, "https://cdn3.devexpress.com/jslib/").Trim();
     devExtremeLocation = devExtremeLocation.WithEnding("/");
     string devExtremeVersion = ViewBagHelper.ValueOrDefault(ViewBag.DevExtremeVersion, "22.2.6").Trim();


### PR DESCRIPTION
Updates default version of jsPDF-AutoTable in HtmlDxDataGrid template to 3.5.29

Fixes #493